### PR TITLE
Make it compile on Java 12

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -28,6 +28,11 @@
     <name>Jakarta EE 8 Specification APIs</name>
     <description>Jakarta EE 8 Specification APIs</description>
 
+    <properties>
+        <!-- we don't process the Jakarta XML Binding and Jakarta SOAP Web Services compile time dependencies -->
+        <extra.excludes>javax/xml/bind/**,javax/xml/ws/**</extra.excludes>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -45,6 +50,9 @@
                         <goals>
                             <goal>generate-pom</goal>
                         </goals>
+                        <configuration>
+                            <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>
+                        </configuration>
                     </execution>                    
                     <execution>
                         <id>attach-all-artifacts</id>
@@ -146,6 +154,20 @@
             <groupId>jakarta.xml.rpc</groupId>
             <artifactId>jakarta.xml.rpc-api</artifactId>
             <version>${jakarta.xml.rpc-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Compile-time dependencies -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>${jakarta.xml.ws-api.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -29,8 +29,8 @@
     <description>Jakarta EE 8 Web Profile Specification APIs</description>
  
     <properties>
-        <!-- we don't process the rpc classes inlined in ejb-api -->
-        <extra.excludes>javax/xml/rpc/**</extra.excludes>
+        <!-- we don't process the rpc classes inlined in ejb-api nor Jakarta XML Binding compile time dependency -->
+        <extra.excludes>javax/xml/rpc/**,javax/xml/bind/**</extra.excludes>
     </properties>
 
     <build>
@@ -50,6 +50,9 @@
                         <goals>
                             <goal>generate-pom</goal>
                         </goals>
+                        <configuration>
+                            <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>attach-all-artifacts</id>
@@ -201,6 +204,14 @@
             <groupId>jakarta.security.enterprise</groupId>
             <artifactId>jakarta.security.enterprise-api</artifactId>
             <version>${jakarta.security.enterprise-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Compile-time dependencies -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
         <!-- Other dependencies -->
         <mojarra.version>2.3.9</mojarra.version>
         <copyright-plugin.version>1.50</copyright-plugin.version>
+
+        <!-- Compile-time dependencies -->
+        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jakarta.xml.ws-api.version>2.3.2</jakarta.xml.ws-api.version>
     </properties>
 
 
@@ -249,7 +253,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <failOnError>false</failOnError>
                         <additionalparam>${javadoc.options}</additionalparam>


### PR DESCRIPTION
Added JAX-B and JAX-WS as compile time dependencies to make it compile on Java 11+. I'm unsure whether those dependencies should be now part of the final JAR.

I avoided referring to them with their acronyms on the pom since that won't be correct from now on.