### PR TITLE
Fix JPA artifacts

### DIFF
--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -40,13 +40,13 @@
                         <goals>
                             <goal>generate-pom</goal>
                         </goals>
-                    </execution>                    
+                    </execution>
                     <execution>
                         <id>attach-all-artifacts</id>
                         <goals>
                             <goal>attach-all-artifacts</goal>
                         </goals>
-                    </execution>  
+                    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -116,8 +116,8 @@
                 <version>${javax.transaction-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>jakarta.persistence</artifactId>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jakarta-persistence-api.version}</version>
             </dependency>
             <dependency>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>jakartaee-web-api</artifactId>
     <name>Jakarta EE 8 Web Profile Specification APIs</name>
     <description>Jakarta EE 8 Web Profile Specification APIs</description>
- 
+
     <properties>
         <!-- we don't process the rpc classes inlined in ejb-api nor Jakarta XML Binding compile time dependency -->
         <extra.excludes>javax/xml/rpc/**,javax/xml/bind/**</extra.excludes>
@@ -159,8 +159,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>jakarta.persistence</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <version>${jakarta-persistence-api.version}</version>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Signed-off-by: Dmitry Kornilov <dmitry.kornilov@oracle.com>

Replaced org.eclipse.persistence with jakarta.persistemce.persistence-api. I think it's right way to do and it fixes the build.