### PR TITLE
Update copyright for generated javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jakarta.jms-api.version>2.0.3</jakarta.jms-api.version>
         <jakarta.mail-api.version>1.6.4</jakarta.mail-api.version>
         <jakarta.resource-api.version>1.7.4</jakarta.resource-api.version>
-        <jakarta.management.j2ee-api.version>1.1.3</jakarta.management.j2ee-api.version>
+        <jakarta.management.j2ee-api.version>1.1.4</jakarta.management.j2ee-api.version>
         <jakarta.security.jacc-api.version>1.6.2</jakarta.security.jacc-api.version>
         <jakarta.enterprise.concurrent-api.version>1.1.2</jakarta.enterprise.concurrent-api.version>
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -260,12 +260,10 @@
                         <doctitle>${project.name}</doctitle>
                         <windowtitle>${project.name}</windowtitle>
                         <bottom>
-<![CDATA[Copyright &#169; 1996-2019,
-    <a href="http://www.oracle.com">Oracle</a>
-    and/or its affiliates. All Rights Reserved.
-    Use is subject to
-    <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
+<![CDATA[
+<p align="left">&#169; Copyright 2019 Eclipse Foundation.<br>Use is subject to
+<a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
+
                         </bottom>
                         <links>
                             <link>http://docs.oracle.com/javase/8/docs/api/</link>


### PR DESCRIPTION
This PR also brings in the update for management-api version update to 1.1.4.  It's a separate PR by itself.  Depending on the order of the merge, we may have some minor cleanup.