### PR TITLE
update pom dependencies with proper versions

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakartaee-web-api</artifactId>
-            <version>${jakartaee.version}</version>
+            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -132,9 +132,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>jakarta.security.jacc</groupId>
-            <artifactId>jakarta.security.jacc-api</artifactId>
-            <version>${jakarta.security.jacc-api.version}</version>
+            <groupId>jakarta.authorization</groupId>
+            <artifactId>jakarta.authorization-api</artifactId>
+            <version>${jakarta.authorization-api.version}</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -178,9 +178,9 @@
                 <version>${jakarta.management.j2ee-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.security.jacc</groupId>
-                <artifactId>jakarta.security.jacc-api</artifactId>
-                <version>${jakarta.security.jacc-api.version}</version>
+                <groupId>jakarta.authorization</groupId>
+                <artifactId>jakarta.authorization-api</artifactId>
+                <version>${jakarta.authorization-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise.concurrent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jakartaee.version>8.0.0-SNAPSHOT</jakartaee.version>
+        <jakartaee.version>8.0.0</jakartaee.version>
         <extra.excludes />
 
         <!-- Web Profile -->
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <jakarta.servlet.jsp-api.version>2.3.6</jakarta.servlet.jsp-api.version>
-        <jakarta.servlet.jsp.jstl-api.version>1.2.4</jakarta.servlet.jsp.jstl-api.version>
-        <jakarta.faces-api.version>2.3.1</jakarta.faces-api.version>
+        <jakarta.servlet.jsp.jstl-api.version>1.2.7</jakarta.servlet.jsp.jstl-api.version>
+        <jakarta.faces-api.version>2.3.2</jakarta.faces-api.version>
         <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
         <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
         <jakarta.json-api.version>1.1.6</jakarta.json-api.version>
@@ -68,7 +68,7 @@
         <jakarta.mail-api.version>1.6.4</jakarta.mail-api.version>
         <jakarta.resource-api.version>1.7.4</jakarta.resource-api.version>
         <jakarta.management.j2ee-api.version>1.1.4</jakarta.management.j2ee-api.version>
-        <jakarta.security.jacc-api.version>1.6.2</jakarta.security.jacc-api.version>
+        <jakarta.authorization-api.version>1.5.0</jakarta.authorization-api.version>
         <jakarta.enterprise.concurrent-api.version>1.1.2</jakarta.enterprise.concurrent-api.version>
         <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>
Found errors while attempting to stage 8.0.0...
https://jenkins.eclipse.org/jakartaee-platform/job/release/2/consoleText

- Modified the dependency GAV for jacc.  Updated version to 1.5.0 at same time.

- Modified webprofile-api dependency to use project.version instead of jakartaee.version.

- Modified jakartaee.version to be 8.0.0 instead of 8.0.0-SNAPSHOT.  This property is still used by the glassfishbuild-maven-plugin.  Not sure how this is used, so I left it.

- And, since I was modifying these pom files, I updated the two missing versions for Faces and JSTL.