### PR TITLE
fix the web profile api artifact id, also a typo in main pom.xml

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -82,7 +82,7 @@
         <!-- Web Profile API  -->
         <dependency>
             <groupId>jakarta.platform</groupId>
-            <artifactId>jakartaee-web-api</artifactId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
                                     <version>1.0</version>
                                 </parent>
                                 <groupId>jakarta.platform</groupId>
-                                <artifactId>${projet.artifactId}</artifactId>
+                                <artifactId>${project.artifactId}</artifactId>
                                 <version>${jakartaee.version}</version>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Missed prepending the "jakarta." to the artifactId for the web-api dependency in the api pom.xml.  As I was reviewing the other poms, I also found a typo in the main pom.xml that was incorrectly referencing ${projet.artifactId} (missing "c" in project).