### PR TITLE
modify pom to attach sources after building for web api

### DIFF
--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -72,6 +72,9 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Next issue with nightly...  The web api sources jar file was not being uploaded during the package phase.  The top level pom had this processing disabled.  I enabled it for web profile api.