### PR TITLE
Fix a typo in BOM's persistence-api version property.

### DIFF
--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${jakarta-persistence-api.version}</version>
+                <version>${jakarta.persistence-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
I tried to import the BOM, but got the following message in Maven's output:
'dependencies.dependency.version' for jakarta.persistence:jakarta.persistence-api:jar must be a valid version but is '${jakarta-persistence-api.version}'.

This PR contains the fix of the variable name, which was already located in the parent pom.xml.

Signed-off-by: krequena <cristian@requena.pro>