### PR TITLE
fixed #46 fixed #46 broken dependency version of jakarta.jms-api in jakarta.jakartaee-bom

### DIFF
--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>jakarta.jms</groupId>
                 <artifactId>jakarta.jms-api</artifactId>
-                <version>${jakarta.messaging-api.version}</version>
+                <version>${jakarta.jms-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.mail</groupId>


### PR DESCRIPTION
fixed #46 broken dependency version of jakarta.jms-api in jakarta.jakartaee-bom

Signed-off-by: Thomas Wöhlke <thomas.woehlke@gmail.com>