### PR TITLE
8.0.0 fixed #44, fixed #45 version of jakarta.jms-api,  jakarta.persistence-api broken in jakarta.jakartaee-bom

### DIFF
--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>jakarta.jms</groupId>
                 <artifactId>jakarta.jms-api</artifactId>
-                <version>${jakarta.messaging-api.version}</version>
+                <version>${jakarta.jms-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.mail</groupId>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${jakarta-persistence-api.version}</version>
+                <version>${jakarta.persistence-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
fixed #44 dependency version of jakarta.jms-api in jakarta.jakartaee-bom broken on Branch 8.0.0-BRANCH

fixed #45 dependency version of jakarta.persistence-api in jakarta.jakartaee-bom broken on Branch 8.0.0-BRANCH

Signed-off-by: Thomas Wöhlke <thomas.woehlke@gmail.com>