### PR TITLE
correct the version name to 8.0.1-SNAPSHOT

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
     <name>Jakarta EE 8 Specification APIs</name>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-bom</artifactId>
     <packaging>pom</packaging>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
     <name>Jakarta EE 8 Web Profile Specification APIs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>
-    <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+    <version>8.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The \<version> in the pom files was incorrect.  It should have been just "8.0.1-SNAPSHOT".