### PR TITLE
Reapply missing PRs

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
     <name>Jakarta EE 8 Specification APIs</name>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-bom</artifactId>
     <packaging>pom</packaging>
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${jakarta-persistence-api.version}</version>
+                <version>${jakarta.persistence-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>jakarta.jms</groupId>
                 <artifactId>jakarta.jms-api</artifactId>
-                <version>${jakarta.messaging-api.version}</version>
+                <version>${jakarta.jms-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.mail</groupId>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+        <version>8.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
     <name>Jakarta EE 8 Web Profile Specification APIs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>
-    <version>8.0.1-SNAPSHOT-SNAPSHOT</version>
+    <version>8.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>


### PR DESCRIPTION
Not sure what happened, but when the 8.0.0-BRANCH was renamed to 8.0.x-BRANCH, some of the PRs were "lost".

I noticed that PR #52 and PR #49 didn't exist in the 8.0.x-BRANCH.  But, when I look at these PRs, they were merged into the old 8.0.0-BRANCH...  No idea why they are missing when all that I did was a simple rename.

Oh well, I'm glad I caught it.  I also updated the parent pom version to 1.0.6 due to our move to the new Nexus instance.