### PR TITLE
Update jakarta dependencies

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -100,13 +100,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!--
-            Using com.sun.mail:jakarta.mail instead of
-            jakarta.mail:jakarta.mail-api because jakarta.mail has a
-            dependency on com.sun.mail classes, but the pom does
-            not bring in the dependency.
-        -->
-
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
@@ -180,6 +173,12 @@
             <version>${mojarra.version}</version>
             <optional>true</optional>
         </dependency>
+        <!--
+            Using com.sun.mail:jakarta.mail instead of
+            jakarta.mail:jakarta.mail-api because jakarta.mail has a
+            dependency on com.sun.mail classes, but the pom does
+            not bring in the dependency.
+        -->
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -30,8 +30,7 @@
 
     <properties>
         <!-- we don't process the Jakarta XML Binding and Jakarta SOAP Web Services compile time dependencies -->
-        <!-- Part of our jar now?  -->
-        <!-- <extra.excludes>jakarta/xml/bind/**,jakarta/xml/ws/**</extra.excludes>  -->
+        <extra.excludes>jakarta/xml/bind/**,jakarta/xml/ws/**</extra.excludes>
     </properties>
 
     <build>
@@ -52,8 +51,7 @@
                             <goal>generate-pom</goal>
                         </goals>
                         <configuration>
-                            <!-- Part of our jar now?  -->
-                            <!-- <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>  -->
+                            <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>
                         </configuration>
                     </execution>
                     <execution>
@@ -89,14 +87,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- work around for GLASSFISH-19861  -->
-        <!-- <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-            <version>${mojarra.version}</version>
-            <optional>true</optional>
-        </dependency>  -->
-
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
@@ -109,6 +99,8 @@
             dependency on com.sun.mail classes, but the pom does
             not bring in the dependency.
         -->
+
+        <!-- TODO Why isn't jakarta.mail ending up in the jar file?  -->
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
@@ -155,7 +147,6 @@
         <!-- Optional APIs -->
 
         <!-- Compile-time dependencies -->
-        <!-- Required dependency now? More than just Compile-time? -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
@@ -168,5 +159,13 @@
             <version>${jakarta.xml.ws-api.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- work around for GLASSFISH-19861  -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${mojarra.version}</version>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 </project>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,12 +25,13 @@
         <version>9.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
-    <name>Jakarta EE 8 Specification APIs</name>
-    <description>Jakarta EE 8 Specification APIs</description>
+    <name>Jakarta EE Specification APIs</name>
+    <description>Jakarta EE Specification APIs</description>
 
     <properties>
         <!-- we don't process the Jakarta XML Binding and Jakarta SOAP Web Services compile time dependencies -->
-        <extra.excludes>javax/xml/bind/**,javax/xml/ws/**</extra.excludes>
+        <!-- Part of our jar now?  -->
+        <!-- <extra.excludes>jakarta/xml/bind/**,jakarta/xml/ws/**</extra.excludes>  -->
     </properties>
 
     <build>
@@ -51,7 +52,8 @@
                             <goal>generate-pom</goal>
                         </goals>
                         <configuration>
-                            <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>
+                            <!-- Part of our jar now?  -->
+                            <!-- <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>  -->
                         </configuration>
                     </execution>
                     <execution>
@@ -88,12 +90,12 @@
         </dependency>
 
         <!-- work around for GLASSFISH-19861  -->
-        <dependency>
+        <!-- <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
             <version>${mojarra.version}</version>
             <optional>true</optional>
-        </dependency>
+        </dependency>  -->
 
         <dependency>
             <groupId>jakarta.jms</groupId>
@@ -103,9 +105,9 @@
         </dependency>
         <!--
             Using com.sun.mail:jakarta.mail instead of
-            jakarta.mail:jakarta.mail-api because javax.mail has a
+            jakarta.mail:jakarta.mail-api because jakarta.mail has a
             dependency on com.sun.mail classes, but the pom does
-            not bring the dependency.
+            not bring in the dependency.
         -->
         <dependency>
             <groupId>jakarta.mail</groupId>
@@ -126,20 +128,14 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>jakarta.management.j2ee</groupId>
-            <artifactId>jakarta.management.j2ee-api</artifactId>
-            <version>${jakarta.management.j2ee-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>jakarta.authorization</groupId>
             <artifactId>jakarta.authorization-api</artifactId>
             <version>${jakarta.authorization-api.version}</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -157,26 +153,9 @@
         </dependency>
 
         <!-- Optional APIs -->
-        <dependency>
-            <groupId>jakarta.enterprise.deploy</groupId>
-            <artifactId>jakarta.enterprise.deploy-api</artifactId>
-            <version>${jakarta.enterprise.deploy-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.registry</groupId>
-            <artifactId>jakarta.xml.registry-api</artifactId>
-            <version>${jakarta.xml.registry-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.rpc</groupId>
-            <artifactId>jakarta.xml.rpc-api</artifactId>
-            <version>${jakarta.xml.rpc-api.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- Compile-time dependencies -->
+        <!-- Required dependency now? More than just Compile-time? -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -93,6 +93,13 @@
             <version>${jakarta.jms-api.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!--
             Using com.sun.mail:jakarta.mail instead of
             jakarta.mail:jakarta.mail-api because jakarta.mail has a
@@ -100,16 +107,9 @@
             not bring in the dependency.
         -->
 
-        <!-- TODO Why isn't jakarta.mail ending up in the jar file?  -->
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
-            <version>${jakarta.mail-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
             <version>${jakarta.mail-api.version}</version>
             <optional>true</optional>
         </dependency>
@@ -145,8 +145,6 @@
         </dependency>
 
         <!-- Optional APIs -->
-
-        <!-- Compile-time dependencies -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
@@ -159,6 +157,22 @@
             <version>${jakarta.xml.ws-api.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+            <version>${jakarta.jws-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+            <version>${jakarta.xml.soap-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+
+
+        <!-- Compile-time dependencies -->
         <!-- work around for GLASSFISH-19861  -->
         <dependency>
             <groupId>org.glassfish</groupId>
@@ -166,6 +180,13 @@
             <version>${mojarra.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>${jakarta.mail-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
 
     </dependencies>
 </project>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -173,11 +173,6 @@
                 <version>${jakarta.resource-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.management.j2ee</groupId>
-                <artifactId>jakarta.management.j2ee-api</artifactId>
-                <version>${jakarta.management.j2ee-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.authorization</groupId>
                 <artifactId>jakarta.authorization-api</artifactId>
                 <version>${jakarta.authorization-api.version}</version>
@@ -194,21 +189,6 @@
             </dependency>
 
             <!-- Optional APIs -->
-            <dependency>
-                <groupId>jakarta.enterprise.deploy</groupId>
-                <artifactId>jakarta.enterprise.deploy-api</artifactId>
-                <version>${jakarta.enterprise.deploy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.registry</groupId>
-                <artifactId>jakarta.xml.registry-api</artifactId>
-                <version>${jakarta.xml.registry-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.rpc</groupId>
-                <artifactId>jakarta.xml.rpc-api</artifactId>
-                <version>${jakarta.xml.rpc-api.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -158,6 +158,11 @@
                 <version>${jakarta.jms-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.mail</groupId>
                 <artifactId>jakarta.mail-api</artifactId>
                 <version>${jakarta.mail-api.version}</version>
@@ -189,6 +194,27 @@
             </dependency>
 
             <!-- Optional APIs -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>${jakarta.xml.ws-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.jws</groupId>
+                <artifactId>jakarta.jws-api</artifactId>
+                <version>${jakarta.jws-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.soap</groupId>
+                <artifactId>jakarta.xml.soap-api</artifactId>
+                <version>${jakarta.xml.soap-api.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 </project>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,12 +25,13 @@
         <version>9.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
-    <name>Jakarta EE 8 Web Profile Specification APIs</name>
-    <description>Jakarta EE 8 Web Profile Specification APIs</description>
+    <name>Jakarta EE Web Profile Specification APIs</name>
+    <description>Jakarta EE Web Profile Specification APIs</description>
 
     <properties>
         <!-- we don't process the rpc classes inlined in ejb-api nor Jakarta XML Binding compile time dependency -->
-        <extra.excludes>javax/xml/rpc/**,javax/xml/bind/**</extra.excludes>
+        <!-- Part of our jar now?  -->
+        <!-- <extra.excludes>jakarta/xml/rpc/**,jakarta/xml/bind/**</extra.excludes>  -->
     </properties>
 
     <build>
@@ -51,7 +52,8 @@
                             <goal>generate-pom</goal>
                         </goals>
                         <configuration>
-                            <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>
+                            <!-- Part of our jar now?  -->
+                            <!-- <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>  -->
                         </configuration>
                     </execution>
                     <execution>
@@ -107,12 +109,12 @@
             <optional>true</optional>
         </dependency>
         <!-- work around for GLASSFISH-19861  -->
-        <dependency>
+        <!-- <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
             <version>${mojarra.version}</version>
             <optional>true</optional>
-        </dependency>
+        </dependency>  -->
         <dependency>
             <groupId>jakarta.faces</groupId>
             <artifactId>jakarta.faces-api</artifactId>
@@ -211,6 +213,7 @@
         </dependency>
 
         <!-- Compile-time dependencies -->
+        <!-- Required dependency now? More than just Compile-time? -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -30,8 +30,7 @@
 
     <properties>
         <!-- we don't process the rpc classes inlined in ejb-api nor Jakarta XML Binding compile time dependency -->
-        <!-- Part of our jar now?  -->
-        <!-- <extra.excludes>jakarta/xml/rpc/**,jakarta/xml/bind/**</extra.excludes>  -->
+        <extra.excludes>jakarta/xml/rpc/**,jakarta/xml/bind/**</extra.excludes>
     </properties>
 
     <build>
@@ -52,8 +51,7 @@
                             <goal>generate-pom</goal>
                         </goals>
                         <configuration>
-                            <!-- Part of our jar now?  -->
-                            <!-- <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>  -->
+                            <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>
                         </configuration>
                     </execution>
                     <execution>
@@ -108,13 +106,6 @@
             <version>${jakarta.servlet.jsp.jstl-api.version}</version>
             <optional>true</optional>
         </dependency>
-        <!-- work around for GLASSFISH-19861  -->
-        <!-- <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-            <version>${mojarra.version}</version>
-            <optional>true</optional>
-        </dependency>  -->
         <dependency>
             <groupId>jakarta.faces</groupId>
             <artifactId>jakarta.faces-api</artifactId>
@@ -213,12 +204,19 @@
         </dependency>
 
         <!-- Compile-time dependencies -->
-        <!-- Required dependency now? More than just Compile-time? -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>${jakarta.xml.bind-api.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- work around for GLASSFISH-19861  -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${mojarra.version}</version>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <!--  Full platform -->
         <jakarta.jms-api.version>3.0.0-RC1</jakarta.jms-api.version>
         <jakarta.activation-api.version>2.0.0-rc1</jakarta.activation-api.version>
-        <jakarta.mail-api.version>2.0.0-RC2</jakarta.mail-api.version>
+        <jakarta.mail-api.version>2.0.0-RC3</jakarta.mail-api.version>
         <jakarta.resource-api.version>2.0.0-RC1</jakarta.resource-api.version>
         <jakarta.authorization-api.version>2.0.0-RC1</jakarta.authorization-api.version>
         <jakarta.enterprise.concurrent-api.version>2.0.0-RC1</jakarta.enterprise.concurrent-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <jakarta.servlet-api.version>5.0.0-M1</jakarta.servlet-api.version>
         <jakarta.servlet.jsp-api.version>3.0.0-M1</jakarta.servlet.jsp-api.version>
         <jakarta.servlet.jsp.jstl-api.version>2.0.0-RC1</jakarta.servlet.jsp.jstl-api.version>
-        <jakarta.faces-api.version>2.3.2</jakarta.faces-api.version> <!-- TODO  -->
+        <jakarta.faces-api.version>3.0.0-RC1</jakarta.faces-api.version>
         <jakarta.el-api.version>4.0.0-RC1</jakarta.el-api.version>
         <jakarta.websocket-api.version>2.0.0-M1</jakarta.websocket-api.version>
         <jakarta.json-api.version>2.0.0-RC1</jakarta.json-api.version>
@@ -63,23 +63,26 @@
         <jakarta.security.enterprise-api.version>2.0.0-RC2</jakarta.security.enterprise-api.version>
         <jakarta.ws.rs-api.version>3.0.0-M1</jakarta.ws.rs-api.version>
 
-      <!--  Full platform -->
+        <!--  Full platform -->
         <jakarta.jms-api.version>3.0.0-RC1</jakarta.jms-api.version>
-        <jakarta.mail-api.version>2.0.0-RC1</jakarta.mail-api.version>
+        <jakarta.activation-api.version>2.0.0-rc1</jakarta.activation-api.version>
+        <jakarta.mail-api.version>2.0.0-RC2</jakarta.mail-api.version>
         <jakarta.resource-api.version>2.0.0-RC1</jakarta.resource-api.version>
         <jakarta.authorization-api.version>2.0.0-RC1</jakarta.authorization-api.version>
         <jakarta.enterprise.concurrent-api.version>2.0.0-RC1</jakarta.enterprise.concurrent-api.version>
         <jakarta.batch-api.version>2.0.0-M1</jakarta.batch-api.version>
 
         <!-- Optional APIs -->
+        <jakarta.xml.bind-api.version>3.0.0-RC1</jakarta.xml.bind-api.version>
+        <jakarta.xml.ws-api.version>3.0.0-RC1</jakarta.xml.ws-api.version>
+        <jakarta.xml.soap-api.version>2.0.0-RC1</jakarta.xml.soap-api.version>
+        <jakarta.jws-api.version>3.0.0-rc1</jakarta.jws-api.version>
 
         <!-- Other dependencies -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
-        <mojarra.version>2.3.14</mojarra.version> <!-- TODO  -->
-        <jakarta.xml.bind-api.version>3.0.0-RC1</jakarta.xml.bind-api.version>
-        <jakarta.xml.ws-api.version>3.0.0-RC1</jakarta.xml.ws-api.version>
+        <mojarra.version>3.0.0</mojarra.version>
     </properties>
 
 
@@ -263,9 +266,8 @@
 
                         </bottom>
                         <links>
-                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                            <link>http://docs.oracle.com/javaee/7/api/</link>
-                            <!-- TODO link for jakarta ee 8 api?  -->
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>https://jakarta.ee/specifications/platform/8/apidocs/</link>
                         </links>
                         <tags>
                             <tag>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
-        <mojarra.version>3.0.0</mojarra.version>
+        <mojarra.version>3.0.0-RC1</mojarra.version>
     </properties>
 
 
@@ -220,7 +220,7 @@
                             <configuration>
                                 <attachSources>true</attachSources>
                                 <excludeArtifactIds>tools-jar,servlet-api,jakarta.faces</excludeArtifactIds>
-                                <excludes>jakarta/help/**,${extra.excludes}</excludes>
+                                <excludes>${extra.excludes}</excludes>
                                 <includes>jakarta/**, resources/**</includes>
                                 <excludeTransitive>true</excludeTransitive>
                             </configuration>
@@ -261,14 +261,10 @@
                         <windowtitle>${project.name}</windowtitle>
                         <bottom>
 <![CDATA[
-<p align="left">Copyright &#169; 2019 Eclipse Foundation.<br>Use is subject to
+<p align="left">Copyright &#169; 2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 
                         </bottom>
-                        <links>
-                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                            <link>https://jakarta.ee/specifications/platform/8/apidocs/</link>
-                        </links>
                         <tags>
                             <tag>
                                 <name>implSpec</name>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
                         <windowtitle>${project.name}</windowtitle>
                         <bottom>
 <![CDATA[
-<p align="left">Copyright &#169; 2020 Eclipse Foundation.<br>Use is subject to
+<p align="left">Copyright &#169; 2019-2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 
                         </bottom>

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
         <!-- Optional APIs -->
 
         <!-- Other dependencies -->
-        <mojarra.version>2.3.14</mojarra.version> <!-- TODO  Still required? -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
+        <mojarra.version>2.3.14</mojarra.version> <!-- TODO  -->
         <jakarta.xml.bind-api.version>3.0.0-RC1</jakarta.xml.bind-api.version>
         <jakarta.xml.ws-api.version>3.0.0-RC1</jakarta.xml.ws-api.version>
     </properties>
@@ -265,6 +265,7 @@
                         <links>
                             <link>http://docs.oracle.com/javase/8/docs/api/</link>
                             <link>http://docs.oracle.com/javaee/7/api/</link>
+                            <!-- TODO link for jakarta ee 8 api?  -->
                         </links>
                         <tags>
                             <tag>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,47 +43,43 @@
         <extra.excludes />
 
         <!-- Web Profile -->
-        <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
-        <jakarta.servlet.jsp-api.version>2.3.6</jakarta.servlet.jsp-api.version>
-        <jakarta.servlet.jsp.jstl-api.version>1.2.7</jakarta.servlet.jsp.jstl-api.version>
-        <jakarta.faces-api.version>2.3.2</jakarta.faces-api.version>
-        <jakarta.el-api.version>3.0.3</jakarta.el-api.version>
-        <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
-        <jakarta.json-api.version>1.1.6</jakarta.json-api.version>
-        <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
-        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
-        <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
-        <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
-        <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
-        <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
-        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
-        <jakarta.inject.version>1.0</jakarta.inject.version>
-        <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
-        <jakarta.security.enterprise-api.version>1.0.2</jakarta.security.enterprise-api.version>
-        <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
+        <jakarta.servlet-api.version>5.0.0-M1</jakarta.servlet-api.version>
+        <jakarta.servlet.jsp-api.version>3.0.0-M1</jakarta.servlet.jsp-api.version>
+        <jakarta.servlet.jsp.jstl-api.version>2.0.0-RC1</jakarta.servlet.jsp.jstl-api.version>
+        <jakarta.faces-api.version>2.3.2</jakarta.faces-api.version> <!-- TODO  -->
+        <jakarta.el-api.version>4.0.0-RC1</jakarta.el-api.version>
+        <jakarta.websocket-api.version>2.0.0-M1</jakarta.websocket-api.version>
+        <jakarta.json-api.version>2.0.0-RC1</jakarta.json-api.version>
+        <jakarta.json.bind-api.version>2.0.0-RC1</jakarta.json.bind-api.version>
+        <jakarta.annotation-api.version>2.0.0-RC1</jakarta.annotation-api.version>
+        <jakarta.ejb-api.version>4.0.0-RC1</jakarta.ejb-api.version>
+        <jakarta.transaction-api.version>2.0.0-RC1</jakarta.transaction-api.version>
+        <jakarta.persistence-api.version>3.0.0-RC1</jakarta.persistence-api.version>
+        <jakarta.validation-api.version>3.0.0-M1</jakarta.validation-api.version>
+        <jakarta.interceptor-api.version>2.0.0-RC2</jakarta.interceptor-api.version>
+        <jakarta.enterprise.cdi-api.version>3.0.0-M1</jakarta.enterprise.cdi-api.version>
+        <jakarta.inject.version>2.0.0-RC2</jakarta.inject.version>
+        <jakarta.security.auth.message-api.version>2.0.0-RC1</jakarta.security.auth.message-api.version>
+        <jakarta.security.enterprise-api.version>2.0.0-RC2</jakarta.security.enterprise-api.version>
+        <jakarta.ws.rs-api.version>3.0.0-M1</jakarta.ws.rs-api.version>
 
       <!--  Full platform -->
-        <jakarta.jms-api.version>2.0.3</jakarta.jms-api.version>
-        <jakarta.mail-api.version>1.6.4</jakarta.mail-api.version>
-        <jakarta.resource-api.version>1.7.4</jakarta.resource-api.version>
-        <jakarta.management.j2ee-api.version>1.1.4</jakarta.management.j2ee-api.version>
-        <jakarta.authorization-api.version>1.5.0</jakarta.authorization-api.version>
-        <jakarta.enterprise.concurrent-api.version>1.1.2</jakarta.enterprise.concurrent-api.version>
-        <jakarta.batch-api.version>1.0.2</jakarta.batch-api.version>
+        <jakarta.jms-api.version>3.0.0-RC1</jakarta.jms-api.version>
+        <jakarta.mail-api.version>2.0.0-RC1</jakarta.mail-api.version>
+        <jakarta.resource-api.version>2.0.0-RC1</jakarta.resource-api.version>
+        <jakarta.authorization-api.version>2.0.0-RC1</jakarta.authorization-api.version>
+        <jakarta.enterprise.concurrent-api.version>2.0.0-RC1</jakarta.enterprise.concurrent-api.version>
+        <jakarta.batch-api.version>2.0.0-M1</jakarta.batch-api.version>
 
         <!-- Optional APIs -->
-        <jakarta.enterprise.deploy-api.version>1.7.2</jakarta.enterprise.deploy-api.version>
-        <jakarta.xml.registry-api.version>1.0.10</jakarta.xml.registry-api.version>
-        <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
 
         <!-- Other dependencies -->
-        <mojarra.version>2.3.9</mojarra.version>
+        <mojarra.version>2.3.14</mojarra.version> <!-- TODO  Still required? -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
-        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
-        <jakarta.xml.ws-api.version>2.3.2</jakarta.xml.ws-api.version>
+        <jakarta.xml.bind-api.version>3.0.0-RC1</jakarta.xml.bind-api.version>
+        <jakarta.xml.ws-api.version>3.0.0-RC1</jakarta.xml.ws-api.version>
     </properties>
 
 
@@ -221,8 +217,8 @@
                             <configuration>
                                 <attachSources>true</attachSources>
                                 <excludeArtifactIds>tools-jar,servlet-api,jakarta.faces</excludeArtifactIds>
-                                <excludes>javax/help/**,${extra.excludes}</excludes>
-                                <includes>javax/**, resources/**</includes>
+                                <excludes>jakarta/help/**,${extra.excludes}</excludes>
+                                <includes>jakarta/**, resources/**</includes>
                                 <excludeTransitive>true</excludeTransitive>
                             </configuration>
                         </execution>


### PR DESCRIPTION
First cut at the updated dependencies for the Jakarta EE 9 Platform and Web Profile APIs.  This is based off of the Milestone / Release Candidate API artifacts as outlined on our [Project Board](https://github.com/orgs/eclipse-ee4j/projects/17#column-7346435).

I'm marking this as a Draft PR at this time because I'm still working through [an issue with Java Mail](https://github.com/eclipse-ee4j/mail/issues/427) and getting the `jakarta` source tree available.

I also did a little bit of cleanup to make it clearer on which dependencies are just for compiling purposes, which ones are optional, etc.