### PR TITLE
Get jenkins working

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -72,6 +72,9 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -72,9 +72,6 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
-                        <configuration>
-                            <attach>true</attach>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -29,8 +29,8 @@
     <description>Jakarta EE Web Profile Specification APIs</description>
 
     <properties>
-        <!-- we don't process the rpc classes inlined in ejb-api nor Jakarta XML Binding compile time dependency -->
-        <extra.excludes>jakarta/xml/rpc/**,jakarta/xml/bind/**</extra.excludes>
+        <!-- we don't process the Jakarta XML Binding compile time dependency -->
+        <extra.excludes>jakarta/xml/bind/**</extra.excludes>
     </properties>
 
     <build>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -72,9 +72,6 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
-                        <configuration>
-                            <attach>true</attach>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.1</version>
                     <configuration>
-                        <attach>false</attach>
+                        <attach>true</attach>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
                     <configuration>
                         <failOnError>false</failOnError>
                         <additionalparam>${javadoc.options}</additionalparam>
-                        <attach>false</attach>
+                        <attach>true</attach>
                         <doclint>none</doclint>
                         <doctitle>${project.name}</doctitle>
                         <windowtitle>${project.name}</windowtitle>


### PR DESCRIPTION
For some reason, the jenkins builds were not producing the proper -sources and -javadoc jar files for the build.  Maybe this was due to some of the pom plugin dependencies that changed since version 1.0.5 of the parent pom.  Not sure.

In any case, I found two configuration items that were required to properly produce and attach these two artifacts.  After some experimenting, I then moved this configuration item to the jakartaee-api parent pom so that we only have it configured in one place.

I also removed the exclude of the rpc apis since they should no longer exist in the ejb api jar file.  RPC is not part of the Jakarta EE 9 effort, so the `jakarta/xml/rpc` package would not exist.

For this effort, I also made a couple of modifications to the [Jenkins "release" job](https://ci.eclipse.org/jakartaee-platform/job/release/) (not under source control).  One was to process the "BRANCH" parameter that defaulted to "master".  With this change, you can now run the Jenkins build against a branch (ie. get-jenkins-working) while working through necessary updates.  And, the other change was to remove the use of the release-phase2 and embedded Profiles on the mvn invocation.  These Profiles do not exist with the build plugins we are using and are probably leftovers from Glassfish builds.  These were causing innocuous warnings during the build.

After this PR is reviewed and merged, then I think we're ready to produce an RC1 of the Platform and Web Profile APIs.