### PR TITLE
update usage and references for efsl for javadoc

### DIFF
--- a/licenses/EFSL.html
+++ b/licenses/EFSL.html
@@ -20,7 +20,7 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      &ldquo;Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php
       &quot;
   </li>
 </ul>
@@ -42,9 +42,9 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
+<p>&quot;Copyright &copy; 2018,2020 Eclipse Foundation. This software or
+  document includes material copied from or derived from 
+  Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/ .&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
                         <windowtitle>${project.name}, ${project.version}</windowtitle>
                         <bottom>
 <![CDATA[
-<p align="left">Copyright &#169; 2019,2020 Eclipse Foundation.<br>Use is subject to
+<p align="left">Copyright &#169; 2018,2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 
                         </bottom>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jakartaee.version>8.0.0</jakartaee.version>
+        <jakartaee.version>9.0.0</jakartaee.version>
         <extra.excludes />
 
         <!-- Web Profile -->
@@ -275,11 +275,11 @@
                         <additionalparam>${javadoc.options}</additionalparam>
                         <attach>true</attach>
                         <doclint>none</doclint>
-                        <doctitle>${project.name}</doctitle>
-                        <windowtitle>${project.name}</windowtitle>
+                        <doctitle>${project.name}, ${project.version}</doctitle>
+                        <windowtitle>${project.name}, ${project.version}</windowtitle>
                         <bottom>
 <![CDATA[
-<p align="left">Copyright &#169; 2019-2020 Eclipse Foundation.<br>Use is subject to
+<p align="left">Copyright &#169; 2019,2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 
                         </bottom>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

- Updated efsl references per Issue #62 
- While updating the references for the efsl, I noticed that the generated javadoc didn't have any indication of the version that was being generated.  So, I updated that in the javadoc title as well.
- I also noticed that the jakartaee.version variable was still set to 8.0.0, so I updated that as well.