### PR TITLE
include version in header of javadoc

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -25,8 +25,8 @@
         <version>9.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
-    <name>Jakarta EE Specification APIs</name>
-    <description>Jakarta EE Specification APIs</description>
+    <name>Jakarta EE Platform API</name>
+    <description>Jakarta EE Platform API</description>
 
     <properties>
         <!-- we don't process the Jakarta XML Binding and Jakarta SOAP Web Services compile time dependencies -->

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -25,8 +25,8 @@
         <version>9.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
-    <name>Jakarta EE Web Profile Specification APIs</name>
-    <description>Jakarta EE Web Profile Specification APIs</description>
+    <name>Jakarta EE Web Profile API</name>
+    <description>Jakarta EE Web Profile API</description>
 
     <properties>
         <!-- we don't process the Jakarta XML Binding compile time dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -275,13 +275,13 @@
                         <additionalparam>${javadoc.options}</additionalparam>
                         <attach>true</attach>
                         <doclint>none</doclint>
-                        <doctitle>${project.name}, ${project.version}</doctitle>
-                        <windowtitle>${project.name}, ${project.version}</windowtitle>
+                        <doctitle>${project.name}</doctitle>
+                        <windowtitle>${project.name}</windowtitle>
+                        <header><![CDATA[<br>${project.name} v${project.version}]]></header>
                         <bottom>
 <![CDATA[
 <p align="left">Copyright &#169; 2018,2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
-
                         </bottom>
                         <tags>
                             <tag>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Putting the version of the project into the header on the generated javadoc pages.  Also, modified the project.name for Platform and Web Profile API to be more consistent.