### PR TITLE
Missing XML Binding and XML Web Services

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -28,11 +28,6 @@
     <name>Jakarta EE Platform API</name>
     <description>Jakarta EE Platform API</description>
 
-    <properties>
-        <!-- we don't process the Jakarta XML Binding and Jakarta SOAP Web Services compile time dependencies -->
-        <extra.excludes>jakarta/xml/bind/**,jakarta/xml/ws/**</extra.excludes>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -50,9 +45,6 @@
                         <goals>
                             <goal>generate-pom</goal>
                         </goals>
-                        <configuration>
-                            <excludeDependencies>jakarta.xml.bind-api,jakarta.xml.ws-api</excludeDependencies>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>attach-all-artifacts</id>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -28,11 +28,6 @@
     <name>Jakarta EE Web Profile API</name>
     <description>Jakarta EE Web Profile API</description>
 
-    <properties>
-        <!-- we don't process the Jakarta XML Binding compile time dependency -->
-        <extra.excludes>jakarta/xml/bind/**</extra.excludes>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -200,13 +195,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Compile-time dependencies -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-            <optional>true</optional>
-        </dependency>
         <!-- work around for GLASSFISH-19861  -->
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -45,9 +45,6 @@
                         <goals>
                             <goal>generate-pom</goal>
                         </goals>
-                        <configuration>
-                            <excludeDependencies>jakarta.xml.bind-api</excludeDependencies>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>attach-all-artifacts</id>


### PR DESCRIPTION
Fixes #67

For platform-api, I removed the extra.excludes property that was preventing it from being copied. The excludeDependencies configuration is also no longer required as these need to be included.

web-api does not need jakarta.xml.bind-api, so I removed the dependency even though it was marked as compile-time dependency. It is not used while building the jar.