### PR TITLE
revert the changes to the EFSL in PR #64

### DIFF
--- a/licenses/EFSL.html
+++ b/licenses/EFSL.html
@@ -42,7 +42,7 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; [$date-of-document] Eclipse Foundation. This software or
   document includes material copied from or derived from [title and URI
   of the Eclipse Foundation specification document].&quot;</p>
 

--- a/licenses/EFSL.html
+++ b/licenses/EFSL.html
@@ -20,7 +20,7 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php
+      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
       &quot;
   </li>
 </ul>
@@ -42,9 +42,9 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018,2020 Eclipse Foundation. This software or
-  document includes material copied from or derived from 
-  Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/ .&quot;</p>
+<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+  document includes material copied from or derived from [title and URI
+  of the Eclipse Foundation specification document].&quot;</p>
 
 <h2>Disclaimers</h2>
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

It has been determined that no changes to the EFSL text are warranted. Based on some invalid information, I had created Issues for all of the Jakarta EE specifications to update the EFSL text used by Specifications and APIs. This was not correct. If the changes were already done, you can leave them as-is for Jakarta EE 9 and correct them in the next release. I have chosen to correct them in Jakarta EE 9 since we are not final yet.