### PR TITLE
Fix license in javadoc footer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
                         <doclint>none</doclint>
                         <doctitle>${project.name}</doctitle>
                         <windowtitle>${project.name}</windowtitle>
+                        <javadocDirectory>${project.basedir}</javadocDirectory>
                         <header><![CDATA[<br>${project.name} v${project.version}]]></header>
                         <bottom>
 <![CDATA[


### PR DESCRIPTION
Set the javadocDirectory property to root folder to copy doc-files folder

