### PR TITLE
update to use 1.0.7 of parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Update to use 1.0.7 version of the parent pom.  Resolved many spurious warnings about "effective module" messages.  This PR will be used to close issue #93.