### PR TITLE
Add jakarta.xml.bind-api to jakartaee-bom

### DIFF
--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -200,6 +200,11 @@
                 <version>${jakarta.enterprise.deploy-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.xml.registry</groupId>
                 <artifactId>jakarta.xml.registry-api</artifactId>
                 <version>${jakarta.xml.registry-api.version}</version>


### PR DESCRIPTION
This dependency is required on JDK11+ since JDK no longer contain these classes because [JEP-320](http://openjdk.java.net/jeps/320) was merged. JDK 9-10 had them in module which needed to be added manually, see [StackOverflow question](https://stackoverflow.com/a/43574427/1049232) for example.

Fixes #101 