### PR TITLE
Add Initial core API

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -71,6 +71,15 @@
     </build>
 
     <dependencies>
+    
+        <!-- Core Profile API  -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Web Profile API  -->
         <dependency>
             <groupId>jakarta.platform</groupId>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -54,6 +54,43 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Core Profile -->
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta.ws.rs-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jakarta.json-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${jakarta.json.bind-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject.version}</version>
+            </dependency>
+
             <!-- Web Profile -->
             <dependency>
                 <groupId>jakarta.servlet</groupId>
@@ -81,29 +118,9 @@
                 <version>${jakarta.faces-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>${jakarta.ws.rs-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.websocket</groupId>
                 <artifactId>jakarta.websocket-api</artifactId>
                 <version>${jakarta.websocket-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.json</groupId>
-                <artifactId>jakarta.json-api</artifactId>
-                <version>${jakarta.json-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.json.bind</groupId>
-                <artifactId>jakarta.json.bind-api</artifactId>
-                <version>${jakarta.json.bind-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.annotation</groupId>
-                <artifactId>jakarta.annotation-api</artifactId>
-                <version>${jakarta.annotation-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.ejb</groupId>
@@ -124,21 +141,6 @@
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${jakarta.validation-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.interceptor</groupId>
-                <artifactId>jakarta.interceptor-api</artifactId>
-                <version>${jakarta.interceptor-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.enterprise</groupId>
-                <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${jakarta.enterprise.cdi-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.inject</groupId>
-                <artifactId>jakarta.inject-api</artifactId>
-                <version>${jakarta.inject.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.authentication</groupId>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>jakarta.platform</groupId>
+        <artifactId>jakartaee-api-parent</artifactId>
+        <version>10-SNAPSHOT</version>
+    </parent>
+    <artifactId>jakarta.jakartaee-core-api</artifactId>
+    <name>Jakarta EE Core Profile API</name>
+    <description>Jakarta EE Web Profile API</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <goals>
+                            <goal>unpack-sources</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-pom</id>
+                        <goals>
+                            <goal>generate-pom</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach-all-artifacts</id>
+                        <goals>
+                            <goal>attach-all-artifacts</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>${jakarta.json-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>${jakarta.json.bind-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${jakarta.enterprise.cdi-api.version}</version>
+            <optional>true</optional>
+            <exclusions>
+              <exclusion>
+                  <groupId>jakarta.inject</groupId>
+                  <artifactId>jakarta.inject-api</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>${jakarta.interceptor-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject.version}</version>
+            <optional>true</optional>
+        </dependency>
+<!-- Uncomment when defined
+        <dependency>
+            <groupId>jakarta.config</groupId>
+            <artifactId>jakarta.config-api</artifactId>
+            <version>${jakarta.config-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+-->
+
+        <!-- Needed for Jakarta REST -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+<!-- TODO: Remve when CDI is replaced by CDI Lite
+     Currently needed for compilation due to Javdoc refs in CDI (SessionBeanType)
+-->        
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>${jakarta.ejb-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,25 @@
 
     <modules>
         <module>jakartaee-bom</module>
+        <module>jakartaee-core-api</module>
         <module>jakartaee-web-api</module>
         <module>jakartaee-api</module>
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jakartaee.version>9.0.0</jakartaee.version>
+        <jakartaee.version>10.0.0</jakartaee.version>
         <extra.excludes />
+
+        <!-- Core Profile -->
+        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
+        <jakarta.json-api.version>2.0.1</jakarta.json-api.version>
+        <jakarta.json.bind-api.version>2.0.0</jakarta.json.bind-api.version>
+        <jakarta.annotation-api.version>2.0.0</jakarta.annotation-api.version>
+        <jakarta.enterprise.cdi-api.version>3.0.0</jakarta.enterprise.cdi-api.version>
+        <jakarta.interceptor-api.version>2.0.0</jakarta.interceptor-api.version>
+        <jakarta.inject.version>2.0.0</jakarta.inject.version>
+        <jakarta.config.version>1.0.0</jakarta.config.version>
 
         <!-- Web Profile -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
@@ -49,19 +60,12 @@
         <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>
         <jakarta.el-api.version>4.0.0</jakarta.el-api.version>
         <jakarta.websocket-api.version>2.0.0</jakarta.websocket-api.version>
-        <jakarta.json-api.version>2.0.1</jakarta.json-api.version>
-        <jakarta.json.bind-api.version>2.0.0</jakarta.json.bind-api.version>
-        <jakarta.annotation-api.version>2.0.0</jakarta.annotation-api.version>
         <jakarta.ejb-api.version>4.0.0</jakarta.ejb-api.version>
         <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
         <jakarta.persistence-api.version>3.0.0</jakarta.persistence-api.version>
         <jakarta.validation-api.version>3.0.0</jakarta.validation-api.version>
-        <jakarta.interceptor-api.version>2.0.0</jakarta.interceptor-api.version>
-        <jakarta.enterprise.cdi-api.version>3.0.0</jakarta.enterprise.cdi-api.version>
-        <jakarta.inject.version>2.0.0</jakarta.inject.version>
         <jakarta.authentication-api.version>2.0.0</jakarta.authentication-api.version>
         <jakarta.security.enterprise-api.version>2.0.0</jakarta.security.enterprise-api.version>
-        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
 
         <!--  Full platform -->
         <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
@@ -267,7 +271,7 @@
                         <header><![CDATA[<br>${project.name} v${project.version}]]></header>
                         <bottom>
 <![CDATA[
-<p align="left">Copyright &#169; 2018,2020 Eclipse Foundation.<br>Use is subject to
+<p align="left">Copyright &#169; 2018,2021 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                         </bottom>
                         <tags>


### PR DESCRIPTION
This is just an initial setup matching the current definition in the spec document. Will need to be updated as we progress with the definitions. 

The versions used here are the 9.1 versions, so they will need to be updated as the individual specs start publishing their artifacts.