### PR TITLE
remove definition of implSpec javadoc tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,13 +267,6 @@
 <p align="left">Copyright &#169; 2018,2020 Eclipse Foundation.<br>Use is subject to
 <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                         </bottom>
-                        <tags>
-                            <tag>
-                                <name>implSpec</name>
-                                <placement>a</placement>
-                                <head>Implementation Specification:</head>
-                            </tag>
-                        </tags>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Since the @implSpec tag is now defined by Java 11, this definition in the pom is no longer necessary for Jakarta EE 10.