### PR TITLE
Current jakartaee-api build expects a x.y.z version format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>
-    <version>10-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>